### PR TITLE
Make Attribute Types more configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi2raml",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Generates RAML for REST APIs that follow JSON-API spec.",
   "main": "index.js",
   "bin": {

--- a/src/assets/models/types/attribute.js
+++ b/src/assets/models/types/attribute.js
@@ -69,9 +69,6 @@ function setupRAML ({ resource }) {
   // For every attribute that the JSON-API Resource being represented has, there
   // should be a property inside the RAML Type.
   Object.keys(resource.attributes).forEach(name => {
-    this.raml.properties[name] = {
-      required: true,
-      type: resource.attributes[name]
-    }
+    this.raml.properties[name] = resource.attributes[name]
   })
 }


### PR DESCRIPTION
Currently when the user documented an attribute of a JSON-API Resource he was only allowed to provide the type name.

Example
```javascript
{
  ...
  "attributes": {
    "name": "string"
  }
  ...
}
````
This commit changes this so that a user will now be able to also provide details about the type's `facets`.

Example
```javascript
{
  ...
  "attributes": {
    "name": {
      "type": "string",
      "maxLength": 10
    }
  }
  ...
}
```