### PR TITLE
Fix error being thrown when Attributes or Relationship is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonapi2raml",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Generates RAML for REST APIs that follow JSON-API spec.",
   "main": "index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -135,8 +135,14 @@ function createResourceTypes (resource) {
     tasks.createAttributeType({ resource }),
     tasks.createRelationshipType({ resource })
   ]).then(([ attributeType, relationshipType ]) => {
-    types[attributeType.name] = attributeType
-    types[relationshipType.name] = relationshipType
+    if (attributeType !== null) {
+      types[attributeType.name] = attributeType
+    }
+
+    if (relationshipType !== null) {
+      types[relationshipType.name] = relationshipType
+    }
+
     // Create Resource RAML Representational Objects.
     return tasks.createResourceType({
       resource, attributeType, relationshipType


### PR DESCRIPTION
Currently when a JSON-API Resource did not have attributes or relationships an error was being thrown. This commit fixes this issue.